### PR TITLE
temporarily disable map embeds

### DIFF
--- a/helpers/osu/url/checkOsuURL.ts
+++ b/helpers/osu/url/checkOsuURL.ts
@@ -30,8 +30,8 @@ export default async (message: Message) => {
 			link.split("/").includes("beatmapsets") &&
 			!link.includes("discussion")
 		)
-			return parseBeatmap(link, message);
-
+			return /*parseBeatmap(link, message)*/;
+			//? temporarily disabling map embeds until i figure out a way to toggle on each embed on its own
 		if (link.split("/").includes("discussion") && !link.includes("reviews"))
 			return parseDiscussionPost(link, message);
 	});


### PR DESCRIPTION
i've mainly got negative feedback about these (mainly because of how much they clutter chats), so i'm disabling them for now until i figure out a way to toggle on and off each embed separately using commands