### PR TITLE
force bot to ignore threads

### DIFF
--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -13,6 +13,10 @@ export default {
 			if (message.channel.type === "DM") return;
 			if (!message.guild) return;
 
+            const validChannelTypes = ["GUILD_TEXT", "GUILD_NEWS", "GUILD_VOICE"];
+
+            if (!validChannelTypes.includes(message.channel.type)) return;
+
 			const botAsMember = message.guild.members.cache.get(
 				bot.user?.id || ""
 			);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "combined-stream": "^1.0.8",
     "d3": "^7.4.0",
     "delayed-stream": "^1.0.0",
-    "discord-api-types": "^0.22.0",
+    "discord-api-types": "^0.37.10",
     "discord.js": "13.8.1",
     "discord.js-pagination": "^1.0.3",
     "dot-prop": "^6.0.1",

--- a/responses/text/yesno.txt
+++ b/responses/text/yesno.txt
@@ -10,14 +10,12 @@ no
 of course not
 nope
 yeah no
-forget it
+nop
 absolutely not
 impossible
 lmao nah
-not sure
-unsure
 maybe
 idk
 ask the other axer
-idk ask nifty
+idk ask hivie
 idk im too busy rn

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,15 +1417,15 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-discord-api-types@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.22.0.tgz#34dc57fe8e016e5eaac5e393646cd42a7e1ccc2a"
-  integrity sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==
-
 discord-api-types@^0.33.3:
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.33.5.tgz#6548b70520f7b944c60984dca4ab58654d664a12"
   integrity sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==
+
+discord-api-types@^0.37.10:
+  version "0.37.10"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.37.10.tgz#d596ed7178f349009e6a9109de5724f11a1de157"
+  integrity sha512-NvDh2Puc3wZQzQt2zLavlI5ewBnLFjI46/NJmvWIs6OC0JOkq7KcmH4s80X2+22mSQ3wUyge2mxq3cGYRT2noQ==
 
 discord.js-pagination@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
workaround for bot crashing whenever a message is sent in forums, at the cost of bot not responding in all threads anymore

should give us more time before needing to implement #199 